### PR TITLE
Cannot find module 

### DIFF
--- a/__tests__/hello_test.re
+++ b/__tests__/hello_test.re
@@ -1,0 +1,12 @@
+open Jest;
+open Expect;
+
+describe("largerThan10", () => {
+  test("< 10", () => {
+    Hello.largerThan10(9) |> expect |> toEqual("< 10")
+  });
+
+  test(">= 10", () => {
+    Hello.largerThan10(10) |> expect |> toEqual(">= 10")
+  })
+});

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,11 @@
 {
   "name": "bisect-starter-bsb-jest",
+  "package-specs": [
+    {
+      "module": "commonjs",
+      "in-source": true
+    }
+  ],
   "bs-dependencies": [
     "bisect_ppx"
   ],

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,13 +1,17 @@
 {
-  "name": "bisect-example-bsb",
+  "name": "bisect-starter-bsb-jest",
   "bs-dependencies": [
     "bisect_ppx"
   ],
+  "bs-dev-dependencies": [
+    "@glennsl/bs-jest"
+  ],
   "ppx-flags": [
-    "bisect_ppx/ppx"
+    ["bisect_ppx/ppx", "--exclude-files", ".*\\/__tests__\\/.*\\.re$$"]
   ],
   "refmt": 3,
   "sources": [
-    "."
+    ".",
+    { "dir": "__tests__", "type": "dev" }
   ]
 }

--- a/hello.re
+++ b/hello.re
@@ -1,12 +1,6 @@
-let () = {
-  Bisect.Runtime.write_coverage_data_on_exit();
-
-  Random.self_init();
-
-  if(Random.int(2) == 0) {
-    print_endline("Hello, world!");
-  }
-  else {
-    print_endline("We come in peace.");
-  }
-};
+let largerThan10 = i =>
+  if (i >= 10) {
+    ">= 10";
+  } else {
+    "< 10";
+  };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,23 @@
 {
-  "name": "bisect-example-bsb",
+  "name": "bisect-starter-bsb-jest",
   "dependencies": {
-    "bisect_ppx": "^2.0.0",
+    "bisect_ppx": "^2.4.0",
     "bs-platform": ">= 5.0.0"
   },
   "scripts": {
     "build": "bsb -make-world",
-    "test": "rm -f *.coverage && node ./lib/js/hello.js",
+    "pretest": "npm run clean && npm run build",
+    "test": "jest",
+    "precoverage": "npm run clean && BISECT_ENABLE=yes npm run build",
+    "coverage": "jest",
     "clean": "bsb -clean-world"
+  },
+  "devDependencies": {
+    "@glennsl/bs-jest": "^0.5.1"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "bisect_ppx/src/runtime/bucklescript/jest.js"
+    ]
   }
 }


### PR DESCRIPTION
```
> bisect-starter-bsb-jest@ coverage /Users/jihchi/Repos/bisect-starter-bsb-jest
> jest

 FAIL  __tests__/hello_test.js
  ● Test suite failed to run

    Cannot find module 'bisect_ppx/lib/js/src/runtime/bucklescript/runtime.js' from 'jest.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:299:11)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.99s
Ran all test suites.
```